### PR TITLE
Ensure v6.4 compatibility

### DIFF
--- a/simrupt.c
+++ b/simrupt.c
@@ -7,6 +7,7 @@
 #include <linux/kfifo.h>
 #include <linux/module.h>
 #include <linux/slab.h>
+#include <linux/version.h>
 #include <linux/workqueue.h>
 
 MODULE_LICENSE("Dual MIT/GPL");
@@ -338,7 +339,11 @@ static int __init simrupt_init(void)
     }
 
     /* Create a class structure */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     simrupt_class = class_create(THIS_MODULE, DEV_NAME);
+#else
+    simrupt_class = class_create(DEV_NAME);
+#endif
     if (IS_ERR(simrupt_class)) {
         printk(KERN_ERR "error creating simrupt class\n");
         ret = PTR_ERR(simrupt_class);


### PR DESCRIPTION
## Summary
In the previous implementation in the function simrupt_init(), we utilize a function call "class_create()" to create a class structure for the kernel module. This function is explicitly called with "class_create(THIS_MODULE, DEV_NAME)", which will cause a compiling error. The reason is the function "class_create()" only allows a single arguments, but two are used here. That's why the corresponding change is made to make sure the basic compiling process is error-free.

## Compiler version
```
gcc-12 (Ubuntu 12.3.0-1ubuntu1~22.04) 12.3.0
```