### PR TITLE
Fix incorrect open count check in release function

### DIFF
--- a/simrupt.c
+++ b/simrupt.c
@@ -298,7 +298,7 @@ static int simrupt_open(struct inode *inode, struct file *filp)
 static int simrupt_release(struct inode *inode, struct file *filp)
 {
     pr_debug("simrupt: %s\n", __func__);
-    if (atomic_dec_and_test(&open_cnt) == 0) {
+    if (atomic_dec_and_test(&open_cnt)) {
         del_timer_sync(&timer);
         flush_workqueue(simrupt_workqueue);
         fast_buf_clear();


### PR DESCRIPTION
After using `insmod` to insert the module, we open three terminals A, B, C.
In terminal C, use the following command to observe the info messages:
```
sudo dmesg --follow
```
In terminal A, B, we both use the following command:
```
sudo cat /dev/simrupt
```
Then, they print out the characters that are produced respectively.
Then, we kill terminal B. We will find that, in terminal A, it stops producing any character as well.

At this time, observing the terminal C, we will find that the reference count is 1, but the producer doesn't produce characters anymore.

```
[256191.736783] simrupt: [CPU#6] simrupt_tasklet_func in_softirq: 7 usec
[256191.736815] simrupt: [CPU#9] simrupt_work_func
[256191.748253] release, current cnt: 1
```

It is because the producer will stop producing characters when `atomic_dec_and_test(&open_cnt)` returns zero in `simrupt_release`. 
```cpp
static int simrupt_release(struct inode *inode, struct file *filp)
{
    pr_debug("simrupt: %s\n", __func__);
    if (atomic_dec_and_test(&open_cnt) == 0) {
        del_timer_sync(&timer);
        flush_workqueue(simrupt_workqueue);
        fast_buf_clear();
    }
    pr_info("release, current cnt: %d\n", atomic_read(&open_cnt));

    return 0;
}
```
Reading the comment of `atomic_dec_and_test`，we will find that it will return true if the resulting value of the variable is zero.
```cpp
/**
 * atomic_dec_and_test() - atomic decrement and test if zero with full ordering
 ...
 * Return: @true if the resulting value of @v is zero, @false otherwise.
 */
```
Therefore, if we want producer to stop producing characters when the `open_cnt` becomes zero, we should do the following change.
```diff
- if (atomic_dec_and_test(&open_cnt) == 0) {
+ if (atomic_dec_and_test(&open_cnt)) {
```
As the result, it works normally.