### PR TITLE
Improve warning message for fast buffer overflow

### DIFF
--- a/simrupt.c
+++ b/simrupt.c
@@ -214,7 +214,9 @@ static void process_data(void)
     WARN_ON_ONCE(!irqs_disabled());
 
     pr_info("simrupt: [CPU#%d] produce data\n", smp_processor_id());
-    fast_buf_put(update_simrupt_data());
+    int ret = fast_buf_put(update_simrupt_data());
+    if (unlikely(ret < 0) && printk_ratelimit())
+        pr_warn("simrupt: fast_buf is full, dropping data\n");
 
     pr_info("simrupt: [CPU#%d] scheduling tasklet\n", smp_processor_id());
     tasklet_schedule(&simrupt_tasklet);


### PR DESCRIPTION
In the original code, when the fast buffer overflows, the return value from fast_buf_put() was silently ignored. This makes it difficult to detect whether any data was lost due to the buffer being full.

To improve the observability, we capture the return value in a local variable and issue a warning when an overflow occurs.