### PR TITLE
Include `<linux/vmalloc.h>` explicitly on x86 

### DIFF
--- a/scripts/aspell-pws
+++ b/scripts/aspell-pws
@@ -177,3 +177,4 @@ kfifo
 PTR
 ttt
 tictactoe
+vmalloc

--- a/simrupt.c
+++ b/simrupt.c
@@ -9,6 +9,9 @@
 #include <linux/slab.h>
 #include <linux/version.h>
 #include <linux/workqueue.h>
+#if defined(CONFIG_X86)
+#include <linux/vmalloc.h>
+#endif
 
 MODULE_LICENSE("Dual MIT/GPL");
 MODULE_AUTHOR("National Cheng Kung University, Taiwan");


### PR DESCRIPTION
Newer kernel versions (>= 5.4) require explicitly including <linux/vmalloc.h> to use vmalloc() and vfree(). Older kernels might have included this implicitly through other headers, but this is no longer the case.

Without this include, builds will fail with implicit function declaration errors on recent kernels such as 6.11.