### PR TITLE
Always include vmalloc.h on all architectures

### DIFF
--- a/simrupt.c
+++ b/simrupt.c
@@ -8,10 +8,8 @@
 #include <linux/module.h>
 #include <linux/slab.h>
 #include <linux/version.h>
-#include <linux/workqueue.h>
-#if defined(CONFIG_X86)
 #include <linux/vmalloc.h>
-#endif
+#include <linux/workqueue.h>
 
 MODULE_LICENSE("Dual MIT/GPL");
 MODULE_AUTHOR("National Cheng Kung University, Taiwan");


### PR DESCRIPTION
Commit 5309792 ("Only include vmalloc.h on x86", #6 ) attempted to limit the inclusion of `<linux/vmalloc.h>` to x86 architectures, based on the assumption that only x86 requires it explicitly.

However, this header is not architecture-specific, and other architectures may include it indirectly. For consistency and future proofing, it's safer to include `<linux/vmalloc.h>` unconditionally, avoiding any potential build issues if indirect dependencies change.