### PR TITLE
Drop .owner for kernel >= 6.4

### DIFF
--- a/simrupt.c
+++ b/simrupt.c
@@ -322,11 +322,13 @@ static int simrupt_release(struct inode *inode, struct file *filp)
 }
 
 static const struct file_operations simrupt_fops = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+    .owner = THIS_MODULE,
+#endif
     .read = simrupt_read,
     .llseek = no_llseek,
     .open = simrupt_open,
     .release = simrupt_release,
-    .owner = THIS_MODULE,
 };
 
 static int __init simrupt_init(void)


### PR DESCRIPTION
Kernel 6.4+ sets .owner automatically. Remove manual assignment to avoid build issues and keep compatibility with older versions.

This change is based on the upstream patch by Greg Kroah-Hartman: [[PATCH 02/12] drivers: remove struct module * setting from struct class](https://lore.kernel.org/lkml/20230313181843.1207845-2-gregkh@linuxfoundation.org/#r)
The patch was first introduced in v6.4-rc1 and officially included in the stable release v6.4.
To verify this,
```shell
$ git log --grep='remove struct module \* setting from struct class'  
$ # Find the commit hash related to the patch
$ git tag --contains 10a03c36b7dd7759788ebc613091d313b60f93e0 
$ # Find the earliest kernel version that includes the commit
```
Relevant tags include:
```shell
...
v6.14
v6.14-rc1
v6.14-rc2
v6.14-rc3
v6.14-rc4
v6.14-rc5
v6.14-rc6
v6.14-rc7
v6.4 # the earliest kernel version
v6.4-rc1
v6.4-rc2
v6.4-rc3
v6.4-rc4
v6.4-rc5
v6.4-rc6
v6.4-rc7
v6.5
...
```