### PR TITLE
Fix incorrect conditional usage of .owner

### DIFF
--- a/simrupt.c
+++ b/simrupt.c
@@ -322,15 +322,13 @@ static int simrupt_release(struct inode *inode, struct file *filp)
 }
 
 static const struct file_operations simrupt_fops = {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-    .owner = THIS_MODULE,
-#endif
     .read = simrupt_read,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
     .llseek = no_llseek,
 #endif
     .open = simrupt_open,
     .release = simrupt_release,
+    .owner = THIS_MODULE,
 };
 
 static int __init simrupt_init(void)


### PR DESCRIPTION
The examples code wrapped .owner = THIS_MODULE inside version checks, suggesting that it is no longer needed after v6.4. This is only true for driver types where the driver core sets .owner automatically (e.g. platform and i2c drivers).

For structures such as struct file_operations, .owner must still be set explicitly by the user. Without it, module reference counting will be broken, allowing a module to be unloaded while still in use, which can lead to kernel panics.

For struct class, the core can safely omit .owner, but explicitly setting it remains correct and safe. Adding conditional #if checks around it only makes the examples harder to read and more confusing for readers.

Remove the unnecessary version guards and unconditionally sets .owner = THIS_MODULE in the affected example code.